### PR TITLE
Fix argument type

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -72,7 +72,7 @@ void hexdump8(const void* buf, size_t len)
 				putchar('\n');
 			}
 
-			printf("%p |", data);
+			printf("%p |", (void*)data);
 		}
 
 		/* group by __HEXDUMP8_GROUP bytes */

--- a/src/yamdns.c
+++ b/src/yamdns.c
@@ -509,7 +509,7 @@ void mdns_packet_dump(const void* buf, size_t len)
 
 err:
 	printf("failed to parse packet on offset 0x%zx (%p):\n",
-		ret, (uint8_t*)buf + ret
+		ret, (void*)((uint8_t*)buf + ret)
 	);
 
 	hexdump8(buf, len);


### PR DESCRIPTION
According to C99 specification, specifier `p` means the argument shall be a pointer to void. 

This commit will fix following compilation error ( clang-800.0.38 ):

```
Scanning dependencies of target yamdns
[ 20%] Building C object CMakeFiles/yamdns.dir/src/main.c.o
[ 40%] Building C object CMakeFiles/yamdns.dir/src/dump.c.o
/Users/bsdelf/project/yamdns/src/dump.c:75:19: error: format specifies type 'void *' but the argument has type
      'const uint8_t *' (aka 'const unsigned char *') [-Werror,-Wformat-pedantic]
                        printf("%p |", data);
                                ~~     ^~~~
                                %s
1 error generated.
```

Reference:
- http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf